### PR TITLE
remove the use of querySelectorAll()

### DIFF
--- a/web-app/iui/iui.js
+++ b/web-app/iui/iui.js
@@ -436,7 +436,12 @@ window.iui =
 	*/
 	getAllViews: function()
 	{
-		return document.querySelectorAll("body > *:not(.toolbar)");
+		var all = document.body.children;
+		for(var i=0,inb=all.length;i<inb;i++) {
+			if(this.hasClass(all[i],'toolbar'))
+				all.splice(i,1);
+		}
+		return all;
 	},
 	
 	/*


### PR DESCRIPTION
We only need it for an easy selection, so let's not use it, that would improve our support for WindowsPhone & old browsers (Blackberry 5, old Opera, ...)
