### PR TITLE
No highlight on tap

### DIFF
--- a/web-app/iui/iui.css
+++ b/web-app/iui/iui.css
@@ -3,6 +3,12 @@
    See LICENSE.txt for licensing terms
    Version @VERSION@
  */
+html {
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
+    -webkit-user-select: none;
+}
+ 
+ 
 body {
     margin: 0;
     font-family: Helvetica;


### PR DESCRIPTION
Dunno how about iOS, but on Android 2.3 buttons and links are highlighted after press (to prevent accidentally clicks or like that). This kills "native feeling" of webapp.
This few lines solves the problem.
